### PR TITLE
Update 3.03.py

### DIFF
--- a/ch03/3.03.py
+++ b/ch03/3.03.py
@@ -9,6 +9,6 @@
 word = raw_input('Word?\n')
 
 def right_justify(s):
-   print " " * (70 - len(word)) + word
+   print " " * (70 - len(s)) + s
 
 right_justify(word)


### PR DESCRIPTION
right_justify(s) 代入的参数是 ‘s’,没有用到，‘print " " * (70 - len(word)) + word ’ 应该修改为 ‘print " " * (70 - len(s)) + s’